### PR TITLE
Update module.json to be compatible with v10 and v9

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,11 +1,16 @@
-{   
-  "name": "swademacros",   
+{ 
+  "id": "swademacros",  
+  "name": "swademacros",
   "title": "Macros for SWADE",
   "description": "Macros for SWADE",   
   "author": "Mestre Digital",
   "version": "0.9.3",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion":"10",
+  "compatibility": {
+    "minimum": "9",
+    "verified": "10"
+  },
   
   "scripts": [],  
 	"esmodules": ["./scripts/init.js"],
@@ -44,7 +49,8 @@
       "label": "Items - Macros for SWADE",
       "path": "packs/items-for-macros.db",
       "entity": "Item",
-      "module": "swademacros"
+      "module": "swademacros",
+      "system": "swade"
     }       
   ],
   
@@ -73,7 +79,19 @@
     
   ],
 
- "styles": [],
+  "relationships": {
+    "systems": [
+      { "id": "swade" }
+    ],
+    "requires": [
+      { "id": "warpgate" },
+      { "id": "compendium-folders" },
+      { "id": "tagger" },
+      { "id": "warpgate" } 
+    ]
+  },
+
+  "styles": [],
   
   "url": "https://github.com/brunocalado/swademacros",
   "manifest": "https://raw.githubusercontent.com/brunocalado/swademacros/main/module.json",  


### PR DESCRIPTION
Currently Foundry will raise multiple warnings for the module because the module.json format was changed in V10. I updated the module.json file in a way that also keeps the old fields as to keep it compatible with v9, but it SHOULD no longer throw warning in v10 (I hope – I'll be honest, I haven't actually tested it).

Here's the reference: https://foundryvtt.com/article/module-development/